### PR TITLE
修复在1.5.1版本下报错:function multiply not defined

### DIFF
--- a/godoc/godoc.go
+++ b/godoc/godoc.go
@@ -98,6 +98,9 @@ func (p *Presentation) initFuncMap() {
 
 		// formatting of Notes
 		"noteTitle": noteTitle,
+
+		// Number operation
+		"multiply": multiply,
 	}
 	if p.URLForSrc != nil {
 		p.funcMap["srcLink"] = p.URLForSrc
@@ -109,6 +112,8 @@ func (p *Presentation) initFuncMap() {
 		p.funcMap["queryLink"] = p.URLForSrcQuery
 	}
 }
+
+func multiply(a, b int) int { return a * b }
 
 func filenameFunc(path string) string {
 	_, localname := pathpkg.Split(path)


### PR DESCRIPTION
修复：https://github.com/golang-china/golangdoc.translations/issues/39
修复：

<pre>
$ golangdoc -http=:6060 -lang=zh_CN
2015/09/30 11:50:22 readTemplate: template: package.html:281: function "multiply" not defined
</pre>
